### PR TITLE
Improve YAML completion regex

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -244,7 +244,7 @@ function registerCompletionProviders() {
         {
             provideCompletionItems(document: vscode.TextDocument, position: vscode.Position) {
                 const linePrefix = document.lineAt(position).text.substr(0, position.character);
-                const match = linePrefix.match(/(\w+):\s*(\w*)$/);
+                const match = linePrefix.match(/^\s*-?\s*(\w+):\s*([\w-]*)$/);
                 
                 if (match) {
                     const [, key, partialValue] = match;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["node", "vscode"],
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */


### PR DESCRIPTION
## Summary
- handle hyphenated YAML keys when providing completions
- configure TypeScript to include Node and VS Code types

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node' and 'vscode')*

------
https://chatgpt.com/codex/tasks/task_e_68404a0118488328befe5426dc05a06e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved YAML completion suggestions to better handle list items and keys with hyphenated partial values.

- **Chores**
  - Updated TypeScript configuration to explicitly include Node.js and VS Code type declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->